### PR TITLE
win環境でビルド失敗するためクォーテーションで囲む

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Sphinxをビルドするのための環境準備
 
-このリポジトリのSphinxでは、ドキュメントに各種 UML 図を埋め込むための Sphinx 拡張「PlantUML」使用しています。
+このリポジトリのSphinxでは、ドキュメントに各種 UML 図を埋め込むための Sphinx 拡張「PlantUML」を使用しています。
 PlantUMLについては以下のサイトを参照してください。
 
 * http://tweeeety.hateblo.jp/entry/2014/10/24/173359
@@ -13,11 +13,11 @@ PlantUMLについては以下のサイトを参照してください。
 
 http://sourceforge.net/projects/plantuml/files/plantuml.jar/download
 
-また、conf.py に以下を追加しています。
+また、plantuml呼び出しのためconf.py に以下を追加しています。
 
     extensions += ['sphinxcontrib.plantuml']
     import os
-    plantuml = 'java -jar ' + os.path.abspath('../plantuml/plantuml.jar')
+    plantuml = 'java -jar "' + os.path.abspath('../plantuml/plantuml.jar') + '" -charset UTF-8'
 
 さらに、シーケンス図以外の UML を使う場合には Graphvizが必要になります。
 GraphvizのインストールはMac/Windows/Linuxで異なりますので詳細はインターネットで検索してみてください。
@@ -29,6 +29,8 @@ GraphvizのインストールはMac/Windows/Linuxで異なりますので詳細�
 masterブランチにpushされたタイミングをTravisCIが検知してビルドが走ります。TravisCIのURLは以下の通り。
 
 * https://travis-ci.org/zunda-cafe/zunda-devstudy-doc
+
+[![Build Status](https://travis-ci.org/zunda-cafe/zunda-devstudy-doc.svg?branch=master)](https://travis-ci.org/zunda-cafe/zunda-devstudy-doc)
 
 GitHubとTravisCIの連携については以下のサイトが参考になります。
 
@@ -56,7 +58,7 @@ TravisCIにGitHubのアカウントでログインすると、所有している
       on:
         branch: master
 
-$GH_TOKEN は後述するGitHub Pages専用のgh-pagesブランチにTravisCIがpushするためのアクセストークンです。取得や設定方法は以下のサイトを参考にしてください。
+`$GH_TOKEN` は後述するGitHub Pages専用のgh-pagesブランチにTravisCIがpushするためのアクセストークンです。取得や設定方法は以下のサイトを参考にしてください。
 
 * http://qiita.com/myyasuda/items/5186fcee00e68ed1bb32
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -156,4 +156,4 @@ texinfo_documents = [
 
 extensions += ['sphinxcontrib.plantuml']
 import os
-plantuml = 'java -jar ' + os.path.abspath('../plantuml/plantuml.jar') + ' -charset UTF-8'
+plantuml = 'java -jar "' + os.path.abspath('../plantuml/plantuml.jar') + '" -charset UTF-8'


### PR DESCRIPTION
# やったこと
1. Windows環境でSphinxビルドが失敗します（PlantUMLの呼び出し部分）
  ![error](https://user-images.githubusercontent.com/12147692/30037893-53283e6c-91fa-11e7-9c54-fd2f06dbe670.png)
2. TravisCIのビルド結果を表示するバッジをREADMEに追記しました。

## 対処内容
相対パス取得部分をダブルクォーテーションで囲っています。
![success](https://user-images.githubusercontent.com/12147692/30037894-5349a8d6-91fa-11e7-9624-1a78ce5e41f6.png)
